### PR TITLE
Mika dev/glfw window handling in class

### DIFF
--- a/.github/actions/build-repo/action.yml
+++ b/.github/actions/build-repo/action.yml
@@ -12,6 +12,7 @@ runs:
       shell: bash
       run: |
         mkdir ../dep
+        sudo apt-get update
         sudo apt-get install libeigen3-dev libtinyxml2-dev
         sudo apt-get install libasound2-dev libusb-1.0.0-dev freeglut3-dev xorg-dev libglew-dev
         sudo apt-get install libglfw3-dev

--- a/examples/01-parse_world_and_robot/main.cpp
+++ b/examples/01-parse_world_and_robot/main.cpp
@@ -16,18 +16,14 @@ int main() {
 	cout << "Loading URDF world model file: " << world_file << endl;
 
 	// load graphics scene
-	auto graphics = new Sai2Graphics::Sai2Graphics(world_file, true);
-	graphics->initializeWindow();
+	auto graphics = new Sai2Graphics::Sai2Graphics(world_file, "sai2 world", true);
 
 	// while window is open:
 	while (graphics->isWindowOpen()) {
 		// update graphics the rendering and the window display.
 		// this automatically waits for the correct amount of time
-		graphics->render(camera_name);
-		graphics->updateWindowWithCameraView(camera_name);
+		graphics->updateDisplayedWorld(camera_name);
 	}
-
-	graphics->closeWindow();
 
 	return 0;
 }

--- a/examples/01-parse_world_and_robot/main.cpp
+++ b/examples/01-parse_world_and_robot/main.cpp
@@ -4,8 +4,6 @@
 
 #include "Sai2Graphics.h"
 
-#include <GLFW/glfw3.h> //must be loaded after loading opengl/glew
-
 #include <iostream>
 #include <string>
 
@@ -14,95 +12,23 @@ using namespace std;
 const string world_file = "resources/world.urdf";
 const string camera_name = "camera_fixed";
 
-// callback to print glfw errors
-void glfwError(int error, const char* description);
-
-// callback when a key is pressed
-void keySelect(GLFWwindow* window, int key, int scancode, int action, int mods);
-
 int main() {
 	cout << "Loading URDF world model file: " << world_file << endl;
 
 	// load graphics scene
 	auto graphics = new Sai2Graphics::Sai2Graphics(world_file, true);
-
-	/*------- Set up visualization -------*/
-    // set up error callback
-    glfwSetErrorCallback(glfwError);
-
-    // initialize GLFW
-    glfwInit();
-
-    // retrieve resolution of computer display and position window accordingly
-    GLFWmonitor* primary = glfwGetPrimaryMonitor();
-    const GLFWvidmode* mode = glfwGetVideoMode(primary);
-
-    // information about computer screen and GLUT display window
-	int screenW = mode->width;
-    int screenH = mode->height;
-    int windowW = 0.8 * screenH;
-    int windowH = 0.5 * screenH;
-    int windowPosY = (screenH - windowH) / 2;
-    int windowPosX = windowPosY;
-
-    // create window and make it current
-    glfwWindowHint(GLFW_VISIBLE, 0);
-    GLFWwindow* window = glfwCreateWindow(windowW, windowH, "01-parse_world_and_robot", NULL, NULL);
-	glfwSetWindowPos(window, windowPosX, windowPosY);
-	glfwShowWindow(window);
-    glfwMakeContextCurrent(window);
-	glfwSwapInterval(1);
-
-    // set callbacks
-	glfwSetKeyCallback(window, keySelect);
+    graphics->initializeWindow();
 
     // while window is open:
-    while (!glfwWindowShouldClose(window))
+    while (graphics->isWindowOpen())
 	{
-		// update graphics. this automatically waits for the correct amount of time
-		int width, height;
-		glfwGetFramebufferSize(window, &width, &height);
-		graphics->render(camera_name, width, height);
-
-		// swap buffers
-		glfwSwapBuffers(window);
-
-		// wait until all GL commands are completed
-		glFinish();
-
-		// check for any OpenGL errors
-		GLenum err;
-		err = glGetError();
-		assert(err == GL_NO_ERROR);
-
-	    // poll for events
-	    glfwPollEvents();
+		// update graphics the rendering and the window display. 
+        // this automatically waits for the correct amount of time
+		graphics->render(camera_name);
+        graphics->updateWindowWithCameraView(camera_name);
 	}
 
-    // destroy context
-    glfwDestroyWindow(window);
-
-    // terminate
-    glfwTerminate();
+    graphics->closeWindow();
 
 	return 0;
-}
-
-//------------------------------------------------------------------------------
-
-void glfwError(int error, const char* description) {
-	cerr << "GLFW Error: " << description << endl;
-	exit(1);
-}
-
-//------------------------------------------------------------------------------
-
-void keySelect(GLFWwindow* window, int key, int scancode, int action, int mods)
-{
-    // option ESC: exit
-    if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)
-    {
-        // exit application
-         glfwSetWindowShouldClose(window, 1);
-    }
 }

--- a/examples/01-parse_world_and_robot/main.cpp
+++ b/examples/01-parse_world_and_robot/main.cpp
@@ -17,18 +17,17 @@ int main() {
 
 	// load graphics scene
 	auto graphics = new Sai2Graphics::Sai2Graphics(world_file, true);
-    graphics->initializeWindow();
+	graphics->initializeWindow();
 
-    // while window is open:
-    while (graphics->isWindowOpen())
-	{
-		// update graphics the rendering and the window display. 
-        // this automatically waits for the correct amount of time
+	// while window is open:
+	while (graphics->isWindowOpen()) {
+		// update graphics the rendering and the window display.
+		// this automatically waits for the correct amount of time
 		graphics->render(camera_name);
-        graphics->updateWindowWithCameraView(camera_name);
+		graphics->updateWindowWithCameraView(camera_name);
 	}
 
-    graphics->closeWindow();
+	graphics->closeWindow();
 
 	return 0;
 }

--- a/examples/02-update_rendering/main.cpp
+++ b/examples/02-update_rendering/main.cpp
@@ -4,8 +4,6 @@
 
 #include "Sai2Graphics.h"
 
-#include <GLFW/glfw3.h> //must be loaded after loading opengl/glew
-
 #include <iostream>
 #include <string>
 
@@ -16,17 +14,12 @@ const string robot_file = "resources/rbot.urdf";
 const string robot_name = "RBot";
 const string camera_name = "camera_fixed";
 
-// callback to print glfw errors
-void glfwError(int error, const char* description);
-
-// callback when a key is pressed
-void keySelect(GLFWwindow* window, int key, int scancode, int action, int mods);
-
 int main() {
 	cout << "Loading URDF world model file: " << world_file << endl;
 
 	// load graphics scene
 	auto graphics = new Sai2Graphics::Sai2Graphics(world_file, true);
+    graphics->initializeWindow();
 
     // load robot
     auto robot = new Sai2Model::Sai2Model(robot_file, false);
@@ -34,92 +27,24 @@ int main() {
     robot->_q.setZero();
     robot->_dq.setZero();
 
-	/*------- Set up visualization -------*/
-    // set up error callback
-    glfwSetErrorCallback(glfwError);
-
-    // initialize GLFW
-    glfwInit();
-
-    // retrieve resolution of computer display and position window accordingly
-    GLFWmonitor* primary = glfwGetPrimaryMonitor();
-    const GLFWvidmode* mode = glfwGetVideoMode(primary);
-
-    // information about computer screen and GLUT display window
-	int screenW = mode->width;
-    int screenH = mode->height;
-    int windowW = 0.8 * screenH;
-    int windowH = 0.5 * screenH;
-    int windowPosY = (screenH - windowH) / 2;
-    int windowPosX = windowPosY;
-
-    // create window and make it current
-    glfwWindowHint(GLFW_VISIBLE, 0);
-    GLFWwindow* window = glfwCreateWindow(windowW, windowH, "02-update_rendering", NULL, NULL);
-	glfwSetWindowPos(window, windowPosX, windowPosY);
-	glfwShowWindow(window);
-    glfwMakeContextCurrent(window);
-	glfwSwapInterval(1);
-
-    // set callbacks
-	glfwSetKeyCallback(window, keySelect);
-
     unsigned long long counter = 0;
 
     // while window is open:
-    while (!glfwWindowShouldClose(window))
+    while (graphics->isWindowOpen())
 	{
         // update robot position
         robot->_q << (double) counter/100.0;
         robot->updateKinematics();
 
-		// update graphics. this automatically waits for the correct amount of time
-		int width, height;
-		glfwGetFramebufferSize(window, &width, &height);
+		// update graphics rendering and window contents
         graphics->updateGraphics(robot_name, robot);
-		graphics->render(camera_name, width, height);
-
-		// swap buffers
-		glfwSwapBuffers(window);
-
-		// wait until all GL commands are completed
-		glFinish();
-
-		// check for any OpenGL errors
-		GLenum err;
-		err = glGetError();
-		assert(err == GL_NO_ERROR);
-
-	    // poll for events
-	    glfwPollEvents();
+		graphics->render(camera_name);
+        graphics->updateWindowWithCameraView(camera_name);
 
         counter++;
 	}
 
-    // destroy context
-    glfwDestroyWindow(window);
-
-    // terminate
-    glfwTerminate();
+    graphics->closeWindow();
 
 	return 0;
-}
-
-//------------------------------------------------------------------------------
-
-void glfwError(int error, const char* description) {
-	cerr << "GLFW Error: " << description << endl;
-	exit(1);
-}
-
-//------------------------------------------------------------------------------
-
-void keySelect(GLFWwindow* window, int key, int scancode, int action, int mods)
-{
-    // option ESC: exit
-    if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)
-    {
-        // exit application
-         glfwSetWindowShouldClose(window, 1);
-    }
 }

--- a/examples/02-update_rendering/main.cpp
+++ b/examples/02-update_rendering/main.cpp
@@ -24,15 +24,15 @@ int main() {
     // load robot
     auto robot = new Sai2Model::Sai2Model(robot_file, false);
     int dof = robot->dof();
-    robot->_q.setZero();
-    robot->_dq.setZero();
+    Eigen::VectorXd next_q = robot->q();
 
     unsigned long long counter = 0;
 
     // while window is open:
     while (graphics->isWindowOpen()) {
         // update robot position
-        robot->_q << (double)counter / 100.0;
+        next_q << (double) counter/100.0;
+        robot->set_q(next_q);
         robot->updateKinematics();
 
         // update graphics rendering and window contents

--- a/examples/02-update_rendering/main.cpp
+++ b/examples/02-update_rendering/main.cpp
@@ -13,18 +13,21 @@ const string world_file = "resources/world.urdf";
 const string robot_file = "resources/rbot.urdf";
 const string robot_name = "RBot";
 const string camera_name = "camera_fixed";
+const string object_name = "Box";
 
 int main() {
     cout << "Loading URDF world model file: " << world_file << endl;
 
     // load graphics scene
-    auto graphics = new Sai2Graphics::Sai2Graphics(world_file, true);
-    graphics->initializeWindow();
+    auto graphics = new Sai2Graphics::Sai2Graphics(world_file);
 
     // load robot
     auto robot = new Sai2Model::Sai2Model(robot_file, false);
     int dof = robot->dof();
     Eigen::VectorXd next_q = robot->q();
+
+    Eigen::Vector3d object_pos = Eigen::Vector3d(0, 0, -1.5);
+    Eigen::Matrix3d object_ori = Eigen::Matrix3d::Identity();
 
     unsigned long long counter = 0;
 
@@ -35,15 +38,17 @@ int main() {
         robot->set_q(next_q);
         robot->updateKinematics();
 
+        // update object position
+        object_pos(1) = -0.4 * sin( (double) counter/100);
+        object_ori *= AngleAxisd( 1.0/100.0, Eigen::Vector3d::UnitX()).toRotationMatrix();
+
         // update graphics rendering and window contents
         graphics->updateGraphics(robot_name, robot);
-        graphics->render(camera_name);
-        graphics->updateWindowWithCameraView(camera_name);
+        graphics->updateObjectGraphics(object_name, object_pos, Eigen::Quaterniond(object_ori));
+        graphics->updateDisplayedWorld(camera_name);
 
         counter++;
     }
-
-    graphics->closeWindow();
 
     return 0;
 }

--- a/examples/02-update_rendering/main.cpp
+++ b/examples/02-update_rendering/main.cpp
@@ -1,5 +1,5 @@
 // This example application loads a URDF world file and simulates two robots
-// with physics and contact in a Dynamics3D virtual world. A graphics model of it is also shown using 
+// with physics and contact in a Dynamics3D virtual world. A graphics model of it is also shown using
 // Chai3D.
 
 #include "Sai2Graphics.h"
@@ -15,10 +15,10 @@ const string robot_name = "RBot";
 const string camera_name = "camera_fixed";
 
 int main() {
-	cout << "Loading URDF world model file: " << world_file << endl;
+    cout << "Loading URDF world model file: " << world_file << endl;
 
-	// load graphics scene
-	auto graphics = new Sai2Graphics::Sai2Graphics(world_file, true);
+    // load graphics scene
+    auto graphics = new Sai2Graphics::Sai2Graphics(world_file, true);
     graphics->initializeWindow();
 
     // load robot
@@ -30,21 +30,20 @@ int main() {
     unsigned long long counter = 0;
 
     // while window is open:
-    while (graphics->isWindowOpen())
-	{
+    while (graphics->isWindowOpen()) {
         // update robot position
-        robot->_q << (double) counter/100.0;
+        robot->_q << (double)counter / 100.0;
         robot->updateKinematics();
 
-		// update graphics rendering and window contents
+        // update graphics rendering and window contents
         graphics->updateGraphics(robot_name, robot);
-		graphics->render(camera_name);
+        graphics->render(camera_name);
         graphics->updateWindowWithCameraView(camera_name);
 
         counter++;
-	}
+    }
 
     graphics->closeWindow();
 
-	return 0;
+    return 0;
 }

--- a/examples/02-update_rendering/world.urdf
+++ b/examples/02-update_rendering/world.urdf
@@ -9,7 +9,18 @@
 		<origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
 	</robot>
 
-
+	<static_object name="Box">
+		<origin xyz="0.0 0.0 -1.5" rpy="0 0 0" />
+	    <visual>
+	        <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
+	        <geometry>
+	            <box size="0.1 0.1 0.1" />
+	        </geometry>
+	        <material name="material_gray">
+		        <color rgba="0.6 0.6 0.6 1.0" />
+	        </material>
+	    </visual>
+	</static_object>
 
 	<light name="light1" type="directional">
 		<position xyz="2.0 -2.0 2.0" />

--- a/src/Sai2Graphics.h
+++ b/src/Sai2Graphics.h
@@ -24,24 +24,11 @@ public:
      * @param verbose To display information about the robot model creation in the terminal or not.
      */
 	Sai2Graphics(const std::string& path_to_world_file,
-					bool verbose = false);
+               const std::string& window_name = "sai2 world",
+               bool verbose = false);
 
 	// dtor
 	~Sai2Graphics();
-
-     // TODO: make part of the constructor (but it will break backwards compatibility)
-     /**
-      * @brief initialize the glfw window with the given window name
-      * 
-      * @param window_name 
-      */
-     void initializeWindow(const std::string& window_name = "sai2 world");
-
-     /**
-      * @brief destroys then glfw context and close the window
-      * 
-      */
-     void closeWindow();
 
      /**
       * @brief returns true is the window is open and should stay open
@@ -61,7 +48,7 @@ public:
       * 
       * @param camera_name the name of the camera to display
       */
-     void updateWindowWithCameraView(const std::string &camera_name);
+     void updateDisplayedWorld(const std::string &camera_name);
 
 	/**
      * @brief Update the graphics model for a robot in the virtual world.
@@ -81,7 +68,39 @@ public:
                          const Eigen::Vector3d& object_pos,
                          const Eigen::Quaterniond object_ori);
 
-     // TODO: make part of updateWindowWithCameraView (will break backwards compatibility)
+     /**
+     * @brief Show frame for a particular link or all links on a robot.
+          This also causes the link graphics as well as graphics for any 
+          child link to be displayed as wire mesh to allow the frame to be
+          seen.
+     * @param show_frame Flag whether should show frame or not.
+     * @param robot_name Robot name.
+     * @param robot_name Link name. If left blank, all link frames are shown.
+     * @param frame_pointer_length Axis arrow length in meters.
+     */
+     void showLinkFrame(bool show_frame,
+                         const std::string& robot_name,
+                         const std::string& link_name = "",
+                         const double frame_pointer_length = 0.03);
+
+     /**
+     * @brief Render wire mesh for a particular link or all links on a robot.
+     * @param show_wiremesh Flag whether should show wire mesh or not.
+     * @param robot_name Robot name.
+     * @param robot_name Link name. If left blank, all link frames are shown.
+     */
+     void showWireMeshRender(bool show_wiremesh,
+                         const std::string& robot_name,
+                         const std::string& link_name = "");
+
+private:
+     /**
+      * @brief initialize the glfw window with the given window name
+      * 
+      * @param window_name 
+      */
+     void initializeWindow(const std::string& window_name);
+
 	/**
      * @brief Render the virtual world to the current context.
      * 	NOTE: the correct context should have been selected prior to this.
@@ -91,10 +110,7 @@ public:
      * @param display_context_id ID for the context to display in. This ID is only to be used
      *	for selective rendering. It does not change the GL context to render to.
      */
-	void render(const std::string& camera_name,
-				int window_width = 0, 
-				int window_height = 0, 
-				int display_context_id = 0);
+	void render(const std::string& camera_name);
 
      /**
      * @brief Return the pose of the camera in the parent frame
@@ -149,31 +165,15 @@ public:
      chai3d::cCamera* getCamera(const std::string& camera_name);
 
      /**
-     * @brief Show frame for a particular link or all links on a robot.
-          This also causes the link graphics as well as graphics for any 
-          child link to be displayed as wire mesh to allow the frame to be
-          seen.
-     * @param show_frame Flag whether should show frame or not.
-     * @param robot_name Robot name.
-     * @param robot_name Link name. If left blank, all link frames are shown.
-     * @param frame_pointer_length Axis arrow length in meters.
+     * internal functions to find link
      */
-     void showLinkFrame(bool show_frame,
-                         const std::string& robot_name,
-                         const std::string& link_name = "",
-                         const double frame_pointer_length = 0.03);
+     chai3d::cRobotLink* findLinkObjectInParentLinkRecursive(chai3d::cRobotLink* parent, const std::string& link_name);
 
-     /**
-     * @brief Render wire mesh for a particular link or all links on a robot.
-     * @param show_wiremesh Flag whether should show wire mesh or not.
-     * @param robot_name Robot name.
-     * @param robot_name Link name. If left blank, all link frames are shown.
-     */
-     void showWireMeshRender(bool show_wiremesh,
-                         const std::string& robot_name,
-                         const std::string& link_name = "");
+     chai3d::cRobotLink* findLink(const std::string& robot_name, const std::string& link_name);
 
-public:
+     void showLinkFrameRecursive(chai3d::cRobotLink* parent, bool show_frame, const double frame_pointer_length);
+
+
 	/**
      * @brief Internal cWorld object.
      */
@@ -209,17 +209,8 @@ public:
      int _window_width;
      int _window_height;
 
-public:
-     /**
-     * internal functions to find link
-     */
-     chai3d::cRobotLink* findLinkObjectInParentLinkRecursive(chai3d::cRobotLink* parent, const std::string& link_name);
-
-     chai3d::cRobotLink* findLink(const std::string& robot_name, const std::string& link_name);
-
-     void showLinkFrameRecursive(chai3d::cRobotLink* parent, bool show_frame, const double frame_pointer_length);
 };
 
-}
+} // namespace
 
 #endif //CHAI_GRAPHICS_H

--- a/src/Sai2Graphics.h
+++ b/src/Sai2Graphics.h
@@ -29,14 +29,38 @@ public:
 	// dtor
 	~Sai2Graphics();
 
+     // TODO: make part of the constructor (but it will break backwards compatibility)
+     /**
+      * @brief initialize the glfw window with the given window name
+      * 
+      * @param window_name 
+      */
      void initializeWindow(const std::string& window_name = "sai2 world");
 
+     /**
+      * @brief destroys then glfw context and close the window
+      * 
+      */
      void closeWindow();
 
+     /**
+      * @brief returns true is the window is open and should stay open
+      * 
+      * @return true 
+      * @return false 
+      */
      bool isWindowOpen() {
           return !glfwWindowShouldClose(_window);
      }
 
+     /**
+      * @brief updates the window display with the most current information
+      * needs to ba called after updateGraphics, updateObjectGraphics
+      * (and render for now) if the changes of robot or object positions are to be
+      * displayed
+      * 
+      * @param camera_name the name of the camera to display
+      */
      void updateWindowWithCameraView(const std::string &camera_name);
 
 	/**
@@ -57,6 +81,7 @@ public:
                          const Eigen::Vector3d& object_pos,
                          const Eigen::Quaterniond object_ori);
 
+     // TODO: make part of updateWindowWithCameraView (will break backwards compatibility)
 	/**
      * @brief Render the virtual world to the current context.
      * 	NOTE: the correct context should have been selected prior to this.
@@ -164,14 +189,25 @@ public:
       * @brief position and direction of view for current camera
       * 
       */
-	Vector3d _camera_pos, _camera_lookat;
 
-	double _last_cursorx, _last_cursory;
+     /**
+      * @brief position of the camera and lookat point
+      * 
+      */
+	Vector3d _camera_pos;
+     Vector3d _camera_lookat_point;
+     Vector3d _camera_up_axis;
 
-     int _window_width, _window_height;
+     /**
+      * @brief used to store the last cursor position
+      * useful when interacting with the window to move the camera
+      * 
+      */
+	double _last_cursorx;
+     double _last_cursory;
 
-
-     std::string _current_camera_name;
+     int _window_width;
+     int _window_height;
 
 public:
      /**

--- a/src/Sai2Graphics.h
+++ b/src/Sai2Graphics.h
@@ -12,6 +12,8 @@
 #include "Sai2Model.h"
 #include "chai_extension/CRobotLink.h"
 
+#include <GLFW/glfw3.h> //must be loaded after loading opengl/glew
+
 namespace Sai2Graphics {
 
 class Sai2Graphics {
@@ -26,6 +28,16 @@ public:
 
 	// dtor
 	~Sai2Graphics();
+
+     void initializeWindow(const std::string& window_name = "sai2 world");
+
+     void closeWindow();
+
+     bool isWindowOpen() {
+          return !glfwWindowShouldClose(_window);
+     }
+
+     void updateWindowWithCameraView(const std::string &camera_name);
 
 	/**
      * @brief Update the graphics model for a robot in the virtual world.
@@ -55,8 +67,8 @@ public:
      *	for selective rendering. It does not change the GL context to render to.
      */
 	void render(const std::string& camera_name,
-				int window_width, 
-				int window_height, 
+				int window_width = 0, 
+				int window_height = 0, 
 				int display_context_id = 0);
 
      /**
@@ -141,6 +153,25 @@ public:
      * @brief Internal cWorld object.
      */
 	chai3d::cWorld* _world;
+
+     /**
+      * @brief glfw window
+      * 
+      */
+     GLFWwindow* _window;
+
+     /**
+      * @brief position and direction of view for current camera
+      * 
+      */
+	Vector3d _camera_pos, _camera_lookat;
+
+	double _last_cursorx, _last_cursory;
+
+     int _window_width, _window_height;
+
+
+     std::string _current_camera_name;
 
 public:
      /**


### PR DESCRIPTION
This PR aims at simplifying the use of sai2 graphics by putting the glfw3 window handling directly in the Sai2Graphics class, which simplifies greatly the applications and limits the duplication of code (see the examples for how much it simplifies things)

It will also make new feature development easier since a new feature will apply to all application instead of having to copy it everywhere

this PR removes backwards compatibility. See examples to see how to make applications up to date.